### PR TITLE
Updates for GemFire for Redis Apps

### DIFF
--- a/content/on-demand-networking.html.md.erb
+++ b/content/on-demand-networking.html.md.erb
@@ -126,17 +126,16 @@ service instance uses cluster defaults for the gateway receiver ports.</td>
     <td>These port numbers are not configurable.</td>
   </tr>
     <tr>
-    <td><strong>Deployed apps on <%=vars.app_runtime_full%> using Redis API</strong></td>
+    <td><strong>Deployed apps on <%=vars.app_runtime_full%> using GemFire For Redis Apps</strong></td>
     <td><strong>Deployed service instances</strong>
     </td>
     <td>
       <ul>
         <li>6379</li>
-        <li>16379 (TLS)</li>
       </ul>
     </td>
     <td>Two-way</td>
-    <td>These port numbers are not configurable. The TLS port is enabled when TLS is enabled for the service instance. If TLS is enabled, the non-TLS port will not be available.</td>
+    <td>There is no separate port for TLS. When TLS is enabled for the service instance this port will also be configured for TLS and all Redis communication (clients) must use TLS.</td>
   </tr>
   <tr>
     <td><strong><%=vars.app_runtime_full%></strong></td>


### PR DESCRIPTION
- Remove mention of port 16379 (since it is not used).
- Add note for TLS usage on port 6379.