### PR TITLE
GEMDOCS-140: Add Using PDX Objects as Region Keys caveat to GF4TAS guide

### DIFF
--- a/content/usage.html.md.erb
+++ b/content/usage.html.md.erb
@@ -22,10 +22,13 @@ title: Recommended Usage and Limitations
 for descriptions of the variety of design patterns that <%=vars.product_full%> supports.
 - <%=vars.product_short%> stores objects in key/value format,
 where the value can be any object.
-- See [gfsh Command Restrictions](using-pcc.html#gfsh-restrictions) for limitations on the use of gfsh commands.
+- Using PDX objects as region entry keys is highly discouraged. See [Using PDX Objects as Region
+  Entry Keys](<%=vars.serverman%>/developing-data_serialization-using_pdx_region_entry_keys.html)
+  for details.
 
 ## Limitations
 
+- See [gfsh Command Restrictions](using-pcc.html#gfsh-restrictions) for limitations on the use of gfsh commands.
 - <%=vars.product_short%> does not support scaling down the cluster.
 - <%=vars.product_short%> does not support plan migrations.
 The `-p` option to the `cf update-service` command is not supported.


### PR DESCRIPTION
Added a one-sentence warning to [Recommended Usage and Limitations](https://docs.vmware.com/en/VMware-GemFire-for-Tanzu-Application-Service/1.14/gf-tas/content-usage.html), as with other items on this page, plus a link to the GF user guide for details.
It is located just below the item that says you can use any object for the value in a key/value pair.
Also relocated the gfsh limitations item under the Limitations sub-heading.